### PR TITLE
Add functionality to read BMW EE Block 15 + Minor improvements

### DIFF
--- a/Arduino/hitag.ino
+++ b/Arduino/hitag.ino
@@ -1,0 +1,684 @@
+/*
+ * (c) Janne Kivijakola
+ * janne@kivijakola.fi
+ */
+
+
+#include <avr/io.h>
+#include <util/delay.h>
+
+//#define F_CPU 16000000UL
+
+const int SCK_pin = 6;
+const int dout_pin = 7;
+const int din_pin = 2; // Arduino Mega2560 original value 21 Mega2560 can also use 2 
+//const int din_pin = 2; //Use with Arduino Nano
+//Note: din_pin must have external interrupt feature!
+
+const int hitagerVersion = 2;
+
+
+#define START_TIMER TCCR1B |= (1 << CS10)
+#define STOP_TIMER TCCR1B &= (0 << CS10)
+
+byte sampcont=0x17;
+
+int isrtimes[400];
+int *isrtimes_ptr = isrtimes;
+volatile int bitsCnt=0;
+volatile int isrCnt=0;
+volatile int capturedone=0;
+unsigned long starttime=0;
+int rfoffset = 2;
+int gain = 1;
+int debug = 0;
+int decodemode = 0;
+int delay_1 = 20;
+int delay_0 = 14;
+int delay_p = 5;
+int hysteresis =1;
+
+void setup()
+{
+  TIMSK0=0;
+  pinMode(SCK_pin, OUTPUT);
+  pinMode(dout_pin, OUTPUT);
+  pinMode(din_pin, INPUT);
+  digitalWrite(SCK_pin, HIGH);
+  digitalWrite(dout_pin, HIGH);
+  digitalWrite(din_pin, HIGH); 
+  Serial.begin(115200); 
+  Serial.println("Init done");
+
+
+  writePCF7991Reg(0x40,8);//wake up
+  writePCF7991Reg(0x50,8);//rf on
+  byte readval = 0;
+  for(int i = 2;i<9;i++)
+  {
+    readval = readPCF7991Reg(i);
+    printRegister(i,readval);
+  }
+
+  Serial.println("set sampling time\n");
+  int samplingT = (1<<7)|(0x3f&sampcont);
+  readval = readPCF7991Reg(samplingT);
+  printRegister(samplingT,readval);
+
+  Serial.println("done registers\n");
+
+}
+void loop()
+{
+  while (Serial.available() < 1)
+  {
+    _delay_ms(1);
+  }
+  byte command = Serial.read();
+  switch(command)
+  {
+    case 'i':
+    {
+      char serialbuf[50];
+      Serial.print("transfer\n");
+      
+      byte cmdlength = serialToByte();
+      if(debug)
+      {
+        sprintf(serialbuf,"length bits: %d\n", cmdlength);
+        Serial.print(serialbuf);
+      }
+      
+      //adapt();
+      byte  authcmd[300] = {0};
+  
+      if(cmdlength > 1 && cmdlength < 200)
+      for(int i = 0; i<(cmdlength+7)/8;i++)
+      {
+        authcmd[i] = serialToByte();
+      }
+      if(debug)
+      {
+        Serial.print("Received command:");
+        for(int i = 0; i<(cmdlength+7)/8;i++)
+        {
+          Serial.print(authcmd[i],HEX);
+          Serial.print(", ");
+        }
+        Serial.print("\n");
+      }
+      communicateTag(authcmd, cmdlength );
+      Serial.print("EOF\n");
+      break;
+    }
+    case 'a':
+    {
+      char serialbuf[50];
+      Serial.print("adapt offset\n");
+      
+      rfoffset = serialToByte();
+      Serial.print("RESP:\n");
+      Serial.print(rfoffset,HEX);
+      Serial.print("\nEOF\n");
+      
+      break;
+    }
+    case 'b':
+    {
+      char serialbuf[50];
+      Serial.print("decoding mode\n");
+      
+      decodemode = serialToByte();
+      Serial.print("RESP:\n");
+      Serial.print(debug,HEX);
+      Serial.print("\nEOF\n");
+      
+      break;
+    }
+    case 'd':
+    {
+      char serialbuf[50];
+      Serial.print("debug mode\n");
+      
+      debug = serialToByte();
+      Serial.print("RESP:\n");
+      Serial.print(debug,HEX);
+      Serial.print("\nEOF\n");
+      
+      break;
+    }
+
+    case 'g':
+    {
+      char serialbuf[50];
+      Serial.print("Gain adjust\n");
+      
+      gain = serialToByte() & 0x3;
+      Serial.print("RESP:\n");
+      Serial.print(gain,HEX);
+      Serial.print("\nEOF\n");
+      
+      break;
+    }
+    case 'h':
+    {
+      char serialbuf[50];
+      Serial.print("Hysteresis\n");
+      
+      hysteresis = serialToByte() & 0x1;
+      Serial.print("RESP:\n");
+      Serial.print(hysteresis,HEX);
+      Serial.print("\nEOF\n");
+      
+      break;
+    }
+
+    case 'o':
+    {
+      writePCF7991Reg(0x40 | (gain<<2) | 0x02, 8);
+      writePCF7991Reg(0x50 | (hysteresis &0x1) <<1,8);//rf on
+      adapt(rfoffset);
+      Serial.print("RFON\n");
+      break;
+    }
+
+    case 'f':
+    {
+      writePCF7991Reg(0x51,8);//rf off
+      Serial.print("RFOFF\n");
+      break;
+    }
+    case 't':
+    {
+      tester();
+      Serial.print("\nEOF\n");
+      break;
+    }
+    case 'v':
+    {
+      Serial.print("Hitager version:");
+      Serial.print(hitagerVersion,HEX);
+      Serial.print("\nEOF\n");
+      break;
+    }
+    case 'z':
+    {
+      char serialbuf[50];
+      Serial.print("Pulse 0 delay adjust\n");
+      
+      delay_0 = serialToByte() & 0xff;
+      Serial.print("RESP:\n");
+      Serial.print(delay_0,HEX);
+      Serial.print("\nEOF\n");
+      
+      break;
+    }
+    case 'x':
+    {
+      char serialbuf[50];
+      Serial.print("Pulse 1 delay adjust\n");
+      
+      delay_1 = serialToByte() & 0xff;
+      Serial.print("RESP:\n");
+      Serial.print(delay_1,HEX);
+      Serial.print("\nEOF\n");
+      
+      break;
+    }
+    case 'c':
+    {
+      char serialbuf[50];
+      Serial.print("Pulse width delay adjust\n");
+      
+      delay_p = serialToByte() & 0xff;
+      Serial.print("RESP:\n");
+      Serial.print(delay_p,HEX);
+      Serial.print("\nEOF\n");
+      
+      break;
+    }
+  }
+  while (Serial.available() > 0)
+  {
+    byte dummyread = Serial.read();
+  }
+
+}
+byte serialToByte()
+{
+  byte retval = 0;
+
+  while (Serial.available() < 2)
+  {
+    
+  }
+
+  for(int i = 0; i<2; i++)
+  {
+    retval<<=4;
+    byte raw = Serial.read();
+    if(raw >= '0' && raw <= '9')
+      retval |= raw-'0';
+    else if(raw >= 'A' && raw <= 'F')
+      retval |= raw-'A'+10;
+    else if(raw >= 'a' && raw <= 'f')
+      retval |= raw-'a'+10;
+      
+  }
+  return retval;
+}
+
+void printRegister(byte addr, byte val)
+{
+  Serial.print("Read addr 0x");
+  Serial.print(addr,HEX);
+  Serial.print(" vslue 0x");
+  Serial.print(val,HEX);
+  Serial.println("");
+}
+
+void tester()
+{
+  isrCnt=0;
+  START_TIMER;
+  attachInterrupt(digitalPinToInterrupt(din_pin) , pin_ISR, CHANGE );
+
+  byte target= readPCF7991Reg(0x08);
+  
+  
+  STOP_TIMER;
+  Serial.print("adapt target:");
+  Serial.println(target,HEX);
+  Serial.print("ISRcnt:");
+  Serial.println(isrCnt,HEX);
+}
+
+byte readPCF7991Reg(byte addr)
+{
+  byte readval = 0;
+  writePCF7991Reg(addr,8);
+  _delay_us(500);
+  readval = readPCF991Response();
+  return readval;
+}
+
+void adapt(int offset)
+{
+  byte target= readPCF7991Reg(0x08);
+  Serial.print("adapt target:");
+  Serial.println(target,HEX);
+  byte samplingT = (1<<7)|(0x3f&(2*target+offset));
+  Serial.print("adapt samplingT:");
+  Serial.println(samplingT,HEX);
+  byte readval = readPCF7991Reg(samplingT);
+  Serial.print("adapt readval:");
+  Serial.println(readval,HEX);
+
+}
+
+byte readPCF991Response()  
+{
+  byte _receive = 0;
+  
+  for(int i=0; i<8; i++)  
+  {
+
+    digitalWrite(SCK_pin, HIGH);   
+    _delay_us(50);
+    bitWrite(_receive, 7-i, digitalRead(din_pin)); 
+    digitalWrite(SCK_pin, LOW);   
+    _delay_us(50);
+  }
+  
+  return _receive;
+}
+
+void writeToTag(byte *data, int bits)
+{
+  int bytes =bits/8;
+  int rembits = bits%8;
+  int bytBits = 8;
+  
+  digitalWrite(SCK_pin, LOW);
+  
+  writePCF7991Reg(0x19,8);
+  //writePCF7991Reg(0x10 | delay_p&0xf,8);
+  digitalWrite(dout_pin, LOW);
+
+  _delay_us(20);//20
+  digitalWrite(dout_pin, HIGH);
+  _delay_us(20);
+  digitalWrite(dout_pin, LOW);
+
+  for(int by=0; by<=bytes; by++) 
+  {
+    if(by==bytes)
+      bytBits=rembits;
+    else
+      bytBits=8;
+      
+    for(int i=0; i<bytBits; i++) 
+    {
+      if( bitRead(data[by], 7-i))
+      {
+        //Serial.print("1");
+        for(int i = 0;i<delay_1; i++)
+          _delay_us(10);//180
+        digitalWrite(dout_pin, HIGH);
+        _delay_us(10);
+        digitalWrite(dout_pin, LOW);
+
+      }
+      else
+      {
+        //Serial.print("0");
+        for(int i = 0;i<delay_0; i++)
+          _delay_us(10);//120
+        digitalWrite(dout_pin, HIGH);
+        _delay_us(10);
+        digitalWrite(dout_pin, LOW);
+
+      }
+  
+    }
+  }
+  
+  //end of transmission
+  _delay_us(500);
+
+}
+
+void readTagResp()
+{
+  writePCF7991Reg(0xe0,3);
+  isrCnt=0;
+  capturedone=0;
+  bitsCnt=0;
+  //byte timski = TIMSK0;
+  //TIMSK0=0;
+  TCCR1B =2;
+  EIFR = (1<<PCIF0);            // Clear EINT0-flag
+  START_TIMER;
+  attachInterrupt(digitalPinToInterrupt(din_pin) , pin_ISR, CHANGE );
+
+  for(volatile int i = 0;i<100;i++)
+    for(volatile int k = 0;k<200;k++);
+
+  //last pulse
+  if(isrCnt<400 && isrCnt>3)
+  {
+    isrtimes_ptr[isrCnt-1]=isrtimes_ptr[isrCnt-2]+201;
+    isrCnt++;
+  }
+  digitalWrite(SCK_pin, HIGH); 
+  STOP_TIMER;
+  //TIMSK0 = timski;
+  detachInterrupt(digitalPinToInterrupt(din_pin));
+
+}
+
+void communicateTag(byte  *tagcmd, unsigned int cmdLengt)
+{
+  isrtimes_ptr=isrtimes;
+  //_delay_ms(10);
+  writeToTag(tagcmd, cmdLengt);
+  //_delay_us(4000);
+  readTagResp();
+
+  Serial.print("ISRcnt:");
+  Serial.println(isrCnt,HEX);
+
+  if(debug)
+  {
+    char hash[5];
+    for(int s=0; s<isrCnt; s++) 
+    {
+      Serial.print(isrtimes[s]);
+      Serial.print(", ");
+    }
+    Serial.print("\n");
+  }
+
+  if(decodemode == 0)
+    processManchester();
+  else
+    processcdp();
+}
+
+
+
+void writePCF7991Reg(byte _send, int bits)  
+{
+
+  pinMode(dout_pin, OUTPUT);
+  digitalWrite(dout_pin, LOW);
+  digitalWrite(SCK_pin, HIGH); 
+  _delay_us(50);
+  digitalWrite(dout_pin, HIGH);
+  _delay_us(50);   
+  digitalWrite(SCK_pin, LOW);   
+  
+  for(int i=0; i<bits; i++) 
+  {
+    digitalWrite(dout_pin, bitRead(_send, 7-i));   
+    _delay_us(50);
+    digitalWrite(SCK_pin, HIGH);                  
+    _delay_us(50);
+    
+    digitalWrite(SCK_pin, LOW);                 
+    _delay_us(50);
+  }
+  
+}
+
+void pin_ISR()
+{
+  unsigned int travelTime = TCNT1; 
+  TCNT1=0;
+
+  if(isrCnt>0)
+  {
+    if(digitalRead(din_pin))
+      travelTime&= ~1;
+    else
+      travelTime|= 1;
+  }
+  else
+  {
+    isrCnt++;
+    return;
+  }
+  isrtimes_ptr[isrCnt-1]=travelTime;
+  if(isrCnt<400)
+    isrCnt++;
+    
+}
+
+void processManchester() 
+{
+  int bitcount =0;
+  int bytecount =0;
+  int mybytes [10] = {0};
+  int lead=0;
+  int errorCnt=0;
+  int state = 1;
+  int start = 0;
+  for(start = 0; start<10; start++)
+  {
+    if(isrtimes_ptr[start]<45)
+      break;
+  }
+  start+=3;
+  if(((isrtimes_ptr[start])&1)==0) 
+   start++;
+
+  for(int i = start; i<isrCnt; i++)
+  {
+    int travelTime = isrtimes_ptr[i];
+    if(((travelTime&1)==1))//high
+    {
+        if(travelTime>45)
+        {
+          //travelTime =11;
+          if(state)
+          {
+            state = 1;
+            if(lead<4)
+            {
+              lead++;
+              //Serial.print("X");
+            }
+            else
+            {
+              mybytes[bytecount] |= (1<<(7-bitcount++));
+              //Serial.print("1");
+            }
+          }
+          else
+          {
+            Serial.print("X");
+            if(bytecount<1)
+              errorCnt++;
+          }
+        }
+        else
+        {
+          //travelTime =1;
+          if(state)
+          {
+            state = 0;
+            if(lead<4)
+              lead++;
+            else
+            {
+              mybytes[bytecount] |= (1<<(7-bitcount++));
+              //Serial.print("1");
+            }
+          }
+          else
+          {
+            state++;
+          }
+        }
+      }
+      else
+      {
+        if(travelTime>45)
+        {
+          if(state)
+          {
+            state = 1;
+            bitcount++;
+            //Serial.print("0");
+          }
+          else
+          {
+            Serial.print("X");
+            if(bytecount<1)
+              errorCnt++;
+          }
+        }
+        else
+        {
+          if(state)
+          {
+            state = 0;
+            bitcount++;
+            //Serial.print("0");
+          }
+          else
+          {
+            state++;
+          }
+        }
+      }
+      if(bitcount>7)
+      {
+        
+        bitcount = 0;
+        bytecount++;
+      }
+      if(travelTime>80)
+      {
+        if(bitcount>0)
+          bytecount++;
+        break;
+      }
+ }
+  
+  char hash[20];
+  Serial.print("\nRESP:");
+  if(errorCnt || bytecount==0 )
+    Serial.print("NORESP\n");
+  else
+    for(int s=0; s<bytecount && s<20; s++) 
+    {
+      sprintf(hash,"%02X", mybytes[s]);
+      Serial.print(hash);
+    
+    }
+  Serial.print("\n");      
+
+}
+
+void processcdp() 
+{
+  int bitcount =0;
+  int bytecount =0;
+  int mybytes [10] = {0};
+  int lead=0;
+  int errorCnt=0;
+  int state = 1;
+  int start = 0;
+  /*
+  for(start = 0; start<10; start++)
+  {
+    if(isrtimes_ptr[start]<45)
+      break;
+  }*/
+  start+=6;
+  if(((isrtimes_ptr[start])&1)==0) 
+   start++;
+
+  for(int i = start; i<isrCnt; i++)
+  {
+    int travelTime = isrtimes_ptr[i];
+    if(travelTime>45)
+    //if(travelTime>80)
+    {
+      mybytes[bytecount] |= (1<<(7-bitcount++));
+      //Serial.print("1");
+    }
+    else 
+    {
+      bitcount++;
+      //Serial.print("0");
+      i++;
+    }      
+    if(bitcount>7)
+    {   
+      bitcount = 0;
+      bytecount++;
+    }
+    if(travelTime>200)
+    {
+      if(bitcount>0)
+        bytecount++;
+      break;
+    }
+ }
+  
+  char hash[20];
+  Serial.print("\nRESP:");
+  if(errorCnt || bytecount==0 )
+    Serial.print("NORESP\n");
+  else
+    for(int s=0; s<bytecount && s<20; s++) 
+    {
+      sprintf(hash,"%02X", mybytes[s]);
+      Serial.print(hash);
+    
+    }
+  Serial.print("\n");      
+
+}

--- a/sources/Hitager/FormHexEditor.resx
+++ b/sources/Hitager/FormHexEditor.resx
@@ -126,7 +126,7 @@
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="openToolStripMenuItem.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+O</value>
+    <value>Control+O</value>
   </data>
   <data name="openToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>146, 22</value>
@@ -141,7 +141,7 @@
     <value>Magenta</value>
   </data>
   <data name="saveToolStripMenuItem.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+S</value>
+    <value>Control+S</value>
   </data>
   <data name="saveToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>146, 22</value>
@@ -181,7 +181,7 @@
     <value>Magenta</value>
   </data>
   <data name="cutToolStripMenuItem.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+X</value>
+    <value>Control+X</value>
   </data>
   <data name="cutToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>200, 22</value>
@@ -193,7 +193,7 @@
     <value>Magenta</value>
   </data>
   <data name="copyToolStripMenuItem.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+C</value>
+    <value>Control+C</value>
   </data>
   <data name="copyToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>200, 22</value>
@@ -205,7 +205,7 @@
     <value>Magenta</value>
   </data>
   <data name="pasteToolStripMenuItem.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+V</value>
+    <value>Control+V</value>
   </data>
   <data name="pasteToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>200, 22</value>
@@ -217,7 +217,7 @@
     <value>197, 6</value>
   </data>
   <data name="copyHexStringToolStripMenuItem.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+Shift+C</value>
+    <value>Control+Shift+C</value>
   </data>
   <data name="copyHexStringToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>200, 22</value>
@@ -226,7 +226,7 @@
     <value>Copy Hex</value>
   </data>
   <data name="pasteHexToolStripMenuItem.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+Shift+V</value>
+    <value>Control+Shift+V</value>
   </data>
   <data name="pasteHexToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>200, 22</value>
@@ -238,7 +238,7 @@
     <value>197, 6</value>
   </data>
   <data name="findToolStripMenuItem.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+F</value>
+    <value>Control+F</value>
   </data>
   <data name="findToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>200, 22</value>
@@ -256,7 +256,7 @@
     <value>Find Next</value>
   </data>
   <data name="goToToolStripMenuItem.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+G</value>
+    <value>Control+G</value>
   </data>
   <data name="goToToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>200, 22</value>
@@ -268,7 +268,7 @@
     <value>197, 6</value>
   </data>
   <data name="selectAllToolStripMenuItem.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+A</value>
+    <value>Control+A</value>
   </data>
   <data name="selectAllToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>200, 22</value>


### PR DESCRIPTION
- Replace "CTL" for keyboard binding in resx file by keyword "Control" in order to ensure compatibility to different language variants of Visual Studio
- Add special procedure to read protected Block 15 on a PCF7944  (5WK49121, old CAS key). This Block contains also crypto data of remote
- Set page to B1B1B1B1 in case of data are not readable. This is a good indicator for the user to see that actually no valid data has been read. It is consistent with comercial HiTag2 v3.1 tool

Annotations:
Do we need "resetBlocks" functionality for BmwHt2? I currently do not see its purpose. My BMW key memory is read without it.
Maybe the following part can be removed?
 `                    if (resetBlocks)
                    {
                        portHandler.portWR("i0500");
                        portHandler.portWR("i0540");
                    }`