### PR TITLE
Bugfix BMW write remote data

### DIFF
--- a/sources/Hitager/BMW_Remote.Designer.cs
+++ b/sources/Hitager/BMW_Remote.Designer.cs
@@ -123,6 +123,7 @@ namespace Hitager
             this.maskedTextBox_KeyNumber.TabIndex = 31;
             this.maskedTextBox_KeyNumber.Text = "0000";
             this.maskedTextBox_KeyNumber.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.maskedTextBox_KeyNumber.TextMaskFormat = System.Windows.Forms.MaskFormat.ExcludePromptAndLiterals;
             // 
             // maskedTextBox_RSK_HI
             // 
@@ -134,6 +135,7 @@ namespace Hitager
             this.maskedTextBox_RSK_HI.TabIndex = 32;
             this.maskedTextBox_RSK_HI.Text = "0000";
             this.maskedTextBox_RSK_HI.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.maskedTextBox_RSK_HI.TextMaskFormat = System.Windows.Forms.MaskFormat.ExcludePromptAndLiterals;
             // 
             // maskedTextBox_RSK_LO
             // 
@@ -145,6 +147,7 @@ namespace Hitager
             this.maskedTextBox_RSK_LO.TabIndex = 33;
             this.maskedTextBox_RSK_LO.Text = "00000000";
             this.maskedTextBox_RSK_LO.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.maskedTextBox_RSK_LO.TextMaskFormat = System.Windows.Forms.MaskFormat.ExcludePromptAndLiterals;
             // 
             // maskedTextBox_Sync
             // 
@@ -156,6 +159,7 @@ namespace Hitager
             this.maskedTextBox_Sync.TabIndex = 34;
             this.maskedTextBox_Sync.Text = "00000000";
             this.maskedTextBox_Sync.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.maskedTextBox_Sync.TextMaskFormat = System.Windows.Forms.MaskFormat.ExcludePromptAndLiterals;
             // 
             // maskedTextBox_Conf
             // 
@@ -167,6 +171,7 @@ namespace Hitager
             this.maskedTextBox_Conf.TabIndex = 35;
             this.maskedTextBox_Conf.Text = "00000000";
             this.maskedTextBox_Conf.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.maskedTextBox_Conf.TextMaskFormat = System.Windows.Forms.MaskFormat.ExcludePromptAndLiterals;
             // 
             // BMW_Remote
             // 

--- a/sources/Hitager/Properties/AssemblyInfo.cs
+++ b/sources/Hitager/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Resources;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]		
 
-[assembly: AssemblyVersion("1.0.2.*")]
+[assembly: AssemblyVersion("1.1.0.*")]
 
 [assembly: ComVisible(false)]
 [assembly: NeutralResourcesLanguage("en-US")]


### PR DESCRIPTION
Due to setting of MaskedTextBox, the whitespaces in remote data were also included into the final command send to arduino tool, which results in an error during processing of the command. This bug was also reported in [issue #2](https://github.com/kivijakola/hitager/issues/2#issuecomment-1096287798).

53f40514d2e8c99e92c57075192f3705d43f883d changes the setting to exclude the whitespace, so command is sent with correct syntax.