### PR TITLE
#BMW Remote: CAS3 EEPROM remote data extractor

### DIFF
--- a/sources/Hitager/BMW_Remote.Designer.cs
+++ b/sources/Hitager/BMW_Remote.Designer.cs
@@ -41,13 +41,21 @@ namespace Hitager
             this.maskedTextBox_RSK_LO = new System.Windows.Forms.MaskedTextBox();
             this.maskedTextBox_Sync = new System.Windows.Forms.MaskedTextBox();
             this.maskedTextBox_Conf = new System.Windows.Forms.MaskedTextBox();
+            this.button_OpenCasDump = new System.Windows.Forms.Button();
+            this.comboBox_bankSelect = new System.Windows.Forms.ComboBox();
+            this.button_FetchRemoteData = new System.Windows.Forms.Button();
+            this.groupBox_CasData = new System.Windows.Forms.GroupBox();
+            this.label_CasDumpStatus = new System.Windows.Forms.Label();
+            this.groupBox_keyData = new System.Windows.Forms.GroupBox();
+            this.groupBox_CasData.SuspendLayout();
+            this.groupBox_keyData.SuspendLayout();
             this.SuspendLayout();
             // 
             // label_RSK_Hi
             // 
             this.label_RSK_Hi.AutoSize = true;
             this.label_RSK_Hi.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label_RSK_Hi.Location = new System.Drawing.Point(24, 47);
+            this.label_RSK_Hi.Location = new System.Drawing.Point(11, 49);
             this.label_RSK_Hi.Name = "label_RSK_Hi";
             this.label_RSK_Hi.Size = new System.Drawing.Size(53, 17);
             this.label_RSK_Hi.TabIndex = 21;
@@ -57,7 +65,7 @@ namespace Hitager
             // 
             this.label_RSK_lo.AutoSize = true;
             this.label_RSK_lo.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label_RSK_lo.Location = new System.Drawing.Point(24, 76);
+            this.label_RSK_lo.Location = new System.Drawing.Point(11, 78);
             this.label_RSK_lo.Name = "label_RSK_lo";
             this.label_RSK_lo.Size = new System.Drawing.Size(56, 17);
             this.label_RSK_lo.TabIndex = 22;
@@ -65,7 +73,7 @@ namespace Hitager
             // 
             // ReadRemote_Button
             // 
-            this.ReadRemote_Button.Location = new System.Drawing.Point(27, 178);
+            this.ReadRemote_Button.Location = new System.Drawing.Point(10, 162);
             this.ReadRemote_Button.Name = "ReadRemote_Button";
             this.ReadRemote_Button.Size = new System.Drawing.Size(87, 36);
             this.ReadRemote_Button.TabIndex = 23;
@@ -77,7 +85,7 @@ namespace Hitager
             // 
             this.label_KeyNumber.AutoSize = true;
             this.label_KeyNumber.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label_KeyNumber.Location = new System.Drawing.Point(24, 18);
+            this.label_KeyNumber.Location = new System.Drawing.Point(11, 20);
             this.label_KeyNumber.Name = "label_KeyNumber";
             this.label_KeyNumber.Size = new System.Drawing.Size(86, 17);
             this.label_KeyNumber.TabIndex = 25;
@@ -87,7 +95,7 @@ namespace Hitager
             // 
             this.label_Sync.AutoSize = true;
             this.label_Sync.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label_Sync.Location = new System.Drawing.Point(24, 105);
+            this.label_Sync.Location = new System.Drawing.Point(11, 107);
             this.label_Sync.Name = "label_Sync";
             this.label_Sync.Size = new System.Drawing.Size(39, 17);
             this.label_Sync.TabIndex = 27;
@@ -97,7 +105,7 @@ namespace Hitager
             // 
             this.label_Conf.AutoSize = true;
             this.label_Conf.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label_Conf.Location = new System.Drawing.Point(24, 134);
+            this.label_Conf.Location = new System.Drawing.Point(11, 136);
             this.label_Conf.Name = "label_Conf";
             this.label_Conf.Size = new System.Drawing.Size(48, 17);
             this.label_Conf.TabIndex = 29;
@@ -105,7 +113,7 @@ namespace Hitager
             // 
             // button_WriteRemote
             // 
-            this.button_WriteRemote.Location = new System.Drawing.Point(127, 178);
+            this.button_WriteRemote.Location = new System.Drawing.Point(124, 162);
             this.button_WriteRemote.Name = "button_WriteRemote";
             this.button_WriteRemote.Size = new System.Drawing.Size(87, 36);
             this.button_WriteRemote.TabIndex = 30;
@@ -116,7 +124,7 @@ namespace Hitager
             // maskedTextBox_KeyNumber
             // 
             this.maskedTextBox_KeyNumber.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.maskedTextBox_KeyNumber.Location = new System.Drawing.Point(168, 15);
+            this.maskedTextBox_KeyNumber.Location = new System.Drawing.Point(165, 17);
             this.maskedTextBox_KeyNumber.Mask = "&& &&";
             this.maskedTextBox_KeyNumber.Name = "maskedTextBox_KeyNumber";
             this.maskedTextBox_KeyNumber.Size = new System.Drawing.Size(46, 23);
@@ -128,7 +136,7 @@ namespace Hitager
             // maskedTextBox_RSK_HI
             // 
             this.maskedTextBox_RSK_HI.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.maskedTextBox_RSK_HI.Location = new System.Drawing.Point(168, 44);
+            this.maskedTextBox_RSK_HI.Location = new System.Drawing.Point(165, 46);
             this.maskedTextBox_RSK_HI.Mask = "&& &&";
             this.maskedTextBox_RSK_HI.Name = "maskedTextBox_RSK_HI";
             this.maskedTextBox_RSK_HI.Size = new System.Drawing.Size(46, 23);
@@ -140,7 +148,7 @@ namespace Hitager
             // maskedTextBox_RSK_LO
             // 
             this.maskedTextBox_RSK_LO.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.maskedTextBox_RSK_LO.Location = new System.Drawing.Point(133, 73);
+            this.maskedTextBox_RSK_LO.Location = new System.Drawing.Point(130, 75);
             this.maskedTextBox_RSK_LO.Mask = "&& && && &&";
             this.maskedTextBox_RSK_LO.Name = "maskedTextBox_RSK_LO";
             this.maskedTextBox_RSK_LO.Size = new System.Drawing.Size(81, 23);
@@ -152,7 +160,7 @@ namespace Hitager
             // maskedTextBox_Sync
             // 
             this.maskedTextBox_Sync.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.maskedTextBox_Sync.Location = new System.Drawing.Point(133, 102);
+            this.maskedTextBox_Sync.Location = new System.Drawing.Point(130, 104);
             this.maskedTextBox_Sync.Mask = "&& && && &&";
             this.maskedTextBox_Sync.Name = "maskedTextBox_Sync";
             this.maskedTextBox_Sync.Size = new System.Drawing.Size(81, 23);
@@ -164,7 +172,7 @@ namespace Hitager
             // maskedTextBox_Conf
             // 
             this.maskedTextBox_Conf.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.maskedTextBox_Conf.Location = new System.Drawing.Point(133, 131);
+            this.maskedTextBox_Conf.Location = new System.Drawing.Point(130, 133);
             this.maskedTextBox_Conf.Mask = "&& && && &&";
             this.maskedTextBox_Conf.Name = "maskedTextBox_Conf";
             this.maskedTextBox_Conf.Size = new System.Drawing.Size(81, 23);
@@ -173,27 +181,92 @@ namespace Hitager
             this.maskedTextBox_Conf.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             this.maskedTextBox_Conf.TextMaskFormat = System.Windows.Forms.MaskFormat.ExcludePromptAndLiterals;
             // 
+            // button_OpenCasDump
+            // 
+            this.button_OpenCasDump.Location = new System.Drawing.Point(10, 45);
+            this.button_OpenCasDump.Name = "button_OpenCasDump";
+            this.button_OpenCasDump.Size = new System.Drawing.Size(104, 21);
+            this.button_OpenCasDump.TabIndex = 36;
+            this.button_OpenCasDump.Text = "Open CAS Dump";
+            this.button_OpenCasDump.UseVisualStyleBackColor = true;
+            this.button_OpenCasDump.Click += new System.EventHandler(this.button_OpenCasDump_Click);
+            // 
+            // comboBox_bankSelect
+            // 
+            this.comboBox_bankSelect.FormattingEnabled = true;
+            this.comboBox_bankSelect.Location = new System.Drawing.Point(10, 18);
+            this.comboBox_bankSelect.Name = "comboBox_bankSelect";
+            this.comboBox_bankSelect.Size = new System.Drawing.Size(150, 21);
+            this.comboBox_bankSelect.TabIndex = 37;
+            // 
+            // button_FetchRemoteData
+            // 
+            this.button_FetchRemoteData.Location = new System.Drawing.Point(166, 18);
+            this.button_FetchRemoteData.Name = "button_FetchRemoteData";
+            this.button_FetchRemoteData.Size = new System.Drawing.Size(53, 21);
+            this.button_FetchRemoteData.TabIndex = 38;
+            this.button_FetchRemoteData.Text = "Fetch";
+            this.button_FetchRemoteData.UseVisualStyleBackColor = true;
+            this.button_FetchRemoteData.Click += new System.EventHandler(this.button_FetchRemoteData_Click);
+            // 
+            // groupBox_CasData
+            // 
+            this.groupBox_CasData.Controls.Add(this.label_CasDumpStatus);
+            this.groupBox_CasData.Controls.Add(this.comboBox_bankSelect);
+            this.groupBox_CasData.Controls.Add(this.button_FetchRemoteData);
+            this.groupBox_CasData.Controls.Add(this.button_OpenCasDump);
+            this.groupBox_CasData.Location = new System.Drawing.Point(12, 210);
+            this.groupBox_CasData.Name = "groupBox_CasData";
+            this.groupBox_CasData.Size = new System.Drawing.Size(225, 100);
+            this.groupBox_CasData.TabIndex = 39;
+            this.groupBox_CasData.TabStop = false;
+            this.groupBox_CasData.Text = "CAS Data";
+            // 
+            // label_CasDumpStatus
+            // 
+            this.label_CasDumpStatus.AutoSize = true;
+            this.label_CasDumpStatus.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_CasDumpStatus.Location = new System.Drawing.Point(11, 69);
+            this.label_CasDumpStatus.Name = "label_CasDumpStatus";
+            this.label_CasDumpStatus.Size = new System.Drawing.Size(48, 17);
+            this.label_CasDumpStatus.TabIndex = 39;
+            this.label_CasDumpStatus.Text = "Status";
+            // 
+            // groupBox_keyData
+            // 
+            this.groupBox_keyData.Controls.Add(this.label_KeyNumber);
+            this.groupBox_keyData.Controls.Add(this.label_RSK_Hi);
+            this.groupBox_keyData.Controls.Add(this.ReadRemote_Button);
+            this.groupBox_keyData.Controls.Add(this.button_WriteRemote);
+            this.groupBox_keyData.Controls.Add(this.maskedTextBox_Conf);
+            this.groupBox_keyData.Controls.Add(this.label_RSK_lo);
+            this.groupBox_keyData.Controls.Add(this.maskedTextBox_Sync);
+            this.groupBox_keyData.Controls.Add(this.label_Sync);
+            this.groupBox_keyData.Controls.Add(this.maskedTextBox_RSK_LO);
+            this.groupBox_keyData.Controls.Add(this.label_Conf);
+            this.groupBox_keyData.Controls.Add(this.maskedTextBox_RSK_HI);
+            this.groupBox_keyData.Controls.Add(this.maskedTextBox_KeyNumber);
+            this.groupBox_keyData.Location = new System.Drawing.Point(12, 2);
+            this.groupBox_keyData.Name = "groupBox_keyData";
+            this.groupBox_keyData.Size = new System.Drawing.Size(225, 204);
+            this.groupBox_keyData.TabIndex = 40;
+            this.groupBox_keyData.TabStop = false;
+            this.groupBox_keyData.Text = "Key Data";
+            // 
             // BMW_Remote
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(239, 235);
-            this.Controls.Add(this.maskedTextBox_Conf);
-            this.Controls.Add(this.maskedTextBox_Sync);
-            this.Controls.Add(this.maskedTextBox_RSK_LO);
-            this.Controls.Add(this.maskedTextBox_RSK_HI);
-            this.Controls.Add(this.maskedTextBox_KeyNumber);
-            this.Controls.Add(this.button_WriteRemote);
-            this.Controls.Add(this.label_Conf);
-            this.Controls.Add(this.label_Sync);
-            this.Controls.Add(this.label_KeyNumber);
-            this.Controls.Add(this.ReadRemote_Button);
-            this.Controls.Add(this.label_RSK_lo);
-            this.Controls.Add(this.label_RSK_Hi);
+            this.ClientSize = new System.Drawing.Size(249, 323);
+            this.Controls.Add(this.groupBox_keyData);
+            this.Controls.Add(this.groupBox_CasData);
             this.Name = "BMW_Remote";
             this.Text = "BMW Remote";
+            this.groupBox_CasData.ResumeLayout(false);
+            this.groupBox_CasData.PerformLayout();
+            this.groupBox_keyData.ResumeLayout(false);
+            this.groupBox_keyData.PerformLayout();
             this.ResumeLayout(false);
-            this.PerformLayout();
 
         }
 
@@ -210,5 +283,11 @@ namespace Hitager
         private System.Windows.Forms.MaskedTextBox maskedTextBox_RSK_LO;
         private System.Windows.Forms.MaskedTextBox maskedTextBox_Sync;
         private System.Windows.Forms.MaskedTextBox maskedTextBox_Conf;
+        private System.Windows.Forms.Button button_OpenCasDump;
+        private System.Windows.Forms.ComboBox comboBox_bankSelect;
+        private System.Windows.Forms.Button button_FetchRemoteData;
+        private System.Windows.Forms.GroupBox groupBox_CasData;
+        private System.Windows.Forms.Label label_CasDumpStatus;
+        private System.Windows.Forms.GroupBox groupBox_keyData;
     }
 }

--- a/sources/Hitager/BMW_Remote.Designer.cs
+++ b/sources/Hitager/BMW_Remote.Designer.cs
@@ -32,11 +32,11 @@ namespace Hitager
             this.label_RSK_Hi = new System.Windows.Forms.Label();
             this.label_RSK_lo = new System.Windows.Forms.Label();
             this.ReadRemote_Button = new System.Windows.Forms.Button();
-            this.label_KeyNumber = new System.Windows.Forms.Label();
+            this.label_RemoteID = new System.Windows.Forms.Label();
             this.label_Sync = new System.Windows.Forms.Label();
             this.label_Conf = new System.Windows.Forms.Label();
             this.button_WriteRemote = new System.Windows.Forms.Button();
-            this.maskedTextBox_KeyNumber = new System.Windows.Forms.MaskedTextBox();
+            this.maskedTextBox_RemoteID = new System.Windows.Forms.MaskedTextBox();
             this.maskedTextBox_RSK_HI = new System.Windows.Forms.MaskedTextBox();
             this.maskedTextBox_RSK_LO = new System.Windows.Forms.MaskedTextBox();
             this.maskedTextBox_Sync = new System.Windows.Forms.MaskedTextBox();
@@ -45,8 +45,9 @@ namespace Hitager
             this.comboBox_bankSelect = new System.Windows.Forms.ComboBox();
             this.button_FetchRemoteData = new System.Windows.Forms.Button();
             this.groupBox_CasData = new System.Windows.Forms.GroupBox();
-            this.label_CasDumpStatus = new System.Windows.Forms.Label();
+            this.label_CasDumpStatusLabel = new System.Windows.Forms.Label();
             this.groupBox_keyData = new System.Windows.Forms.GroupBox();
+            this.label_CasDumpStatus = new System.Windows.Forms.Label();
             this.groupBox_CasData.SuspendLayout();
             this.groupBox_keyData.SuspendLayout();
             this.SuspendLayout();
@@ -81,15 +82,15 @@ namespace Hitager
             this.ReadRemote_Button.UseVisualStyleBackColor = true;
             this.ReadRemote_Button.Click += new System.EventHandler(this.Read_Remote_Click);
             // 
-            // label_KeyNumber
+            // label_RemoteID
             // 
-            this.label_KeyNumber.AutoSize = true;
-            this.label_KeyNumber.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label_KeyNumber.Location = new System.Drawing.Point(11, 20);
-            this.label_KeyNumber.Name = "label_KeyNumber";
-            this.label_KeyNumber.Size = new System.Drawing.Size(86, 17);
-            this.label_KeyNumber.TabIndex = 25;
-            this.label_KeyNumber.Text = "Key Number";
+            this.label_RemoteID.AutoSize = true;
+            this.label_RemoteID.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_RemoteID.Location = new System.Drawing.Point(11, 20);
+            this.label_RemoteID.Name = "label_RemoteID";
+            this.label_RemoteID.Size = new System.Drawing.Size(86, 17);
+            this.label_RemoteID.TabIndex = 25;
+            this.label_RemoteID.Text = "Key Number";
             // 
             // label_Sync
             // 
@@ -121,17 +122,17 @@ namespace Hitager
             this.button_WriteRemote.UseVisualStyleBackColor = true;
             this.button_WriteRemote.Click += new System.EventHandler(this.button_WriteRemote_Click);
             // 
-            // maskedTextBox_KeyNumber
+            // maskedTextBox_RemoteID
             // 
-            this.maskedTextBox_KeyNumber.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.maskedTextBox_KeyNumber.Location = new System.Drawing.Point(165, 17);
-            this.maskedTextBox_KeyNumber.Mask = "&& &&";
-            this.maskedTextBox_KeyNumber.Name = "maskedTextBox_KeyNumber";
-            this.maskedTextBox_KeyNumber.Size = new System.Drawing.Size(46, 23);
-            this.maskedTextBox_KeyNumber.TabIndex = 31;
-            this.maskedTextBox_KeyNumber.Text = "0000";
-            this.maskedTextBox_KeyNumber.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.maskedTextBox_KeyNumber.TextMaskFormat = System.Windows.Forms.MaskFormat.ExcludePromptAndLiterals;
+            this.maskedTextBox_RemoteID.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.maskedTextBox_RemoteID.Location = new System.Drawing.Point(165, 17);
+            this.maskedTextBox_RemoteID.Mask = "&& &&";
+            this.maskedTextBox_RemoteID.Name = "maskedTextBox_RemoteID";
+            this.maskedTextBox_RemoteID.Size = new System.Drawing.Size(46, 23);
+            this.maskedTextBox_RemoteID.TabIndex = 31;
+            this.maskedTextBox_RemoteID.Text = "0000";
+            this.maskedTextBox_RemoteID.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.maskedTextBox_RemoteID.TextMaskFormat = System.Windows.Forms.MaskFormat.ExcludePromptAndLiterals;
             // 
             // maskedTextBox_RSK_HI
             // 
@@ -183,7 +184,7 @@ namespace Hitager
             // 
             // button_OpenCasDump
             // 
-            this.button_OpenCasDump.Location = new System.Drawing.Point(10, 45);
+            this.button_OpenCasDump.Location = new System.Drawing.Point(10, 19);
             this.button_OpenCasDump.Name = "button_OpenCasDump";
             this.button_OpenCasDump.Size = new System.Drawing.Size(104, 21);
             this.button_OpenCasDump.TabIndex = 36;
@@ -194,24 +195,25 @@ namespace Hitager
             // comboBox_bankSelect
             // 
             this.comboBox_bankSelect.FormattingEnabled = true;
-            this.comboBox_bankSelect.Location = new System.Drawing.Point(10, 18);
+            this.comboBox_bankSelect.Location = new System.Drawing.Point(10, 73);
             this.comboBox_bankSelect.Name = "comboBox_bankSelect";
-            this.comboBox_bankSelect.Size = new System.Drawing.Size(150, 21);
+            this.comboBox_bankSelect.Size = new System.Drawing.Size(130, 21);
             this.comboBox_bankSelect.TabIndex = 37;
             // 
             // button_FetchRemoteData
             // 
-            this.button_FetchRemoteData.Location = new System.Drawing.Point(166, 18);
+            this.button_FetchRemoteData.Location = new System.Drawing.Point(146, 73);
             this.button_FetchRemoteData.Name = "button_FetchRemoteData";
-            this.button_FetchRemoteData.Size = new System.Drawing.Size(53, 21);
+            this.button_FetchRemoteData.Size = new System.Drawing.Size(73, 21);
             this.button_FetchRemoteData.TabIndex = 38;
-            this.button_FetchRemoteData.Text = "Fetch";
+            this.button_FetchRemoteData.Text = "Get Data";
             this.button_FetchRemoteData.UseVisualStyleBackColor = true;
             this.button_FetchRemoteData.Click += new System.EventHandler(this.button_FetchRemoteData_Click);
             // 
             // groupBox_CasData
             // 
             this.groupBox_CasData.Controls.Add(this.label_CasDumpStatus);
+            this.groupBox_CasData.Controls.Add(this.label_CasDumpStatusLabel);
             this.groupBox_CasData.Controls.Add(this.comboBox_bankSelect);
             this.groupBox_CasData.Controls.Add(this.button_FetchRemoteData);
             this.groupBox_CasData.Controls.Add(this.button_OpenCasDump);
@@ -222,19 +224,19 @@ namespace Hitager
             this.groupBox_CasData.TabStop = false;
             this.groupBox_CasData.Text = "CAS Data";
             // 
-            // label_CasDumpStatus
+            // label_CasDumpStatusLabel
             // 
-            this.label_CasDumpStatus.AutoSize = true;
-            this.label_CasDumpStatus.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label_CasDumpStatus.Location = new System.Drawing.Point(11, 69);
-            this.label_CasDumpStatus.Name = "label_CasDumpStatus";
-            this.label_CasDumpStatus.Size = new System.Drawing.Size(48, 17);
-            this.label_CasDumpStatus.TabIndex = 39;
-            this.label_CasDumpStatus.Text = "Status";
+            this.label_CasDumpStatusLabel.AutoSize = true;
+            this.label_CasDumpStatusLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_CasDumpStatusLabel.Location = new System.Drawing.Point(11, 43);
+            this.label_CasDumpStatusLabel.Name = "label_CasDumpStatusLabel";
+            this.label_CasDumpStatusLabel.Size = new System.Drawing.Size(93, 17);
+            this.label_CasDumpStatusLabel.TabIndex = 39;
+            this.label_CasDumpStatusLabel.Text = "Dump Status:";
             // 
             // groupBox_keyData
             // 
-            this.groupBox_keyData.Controls.Add(this.label_KeyNumber);
+            this.groupBox_keyData.Controls.Add(this.label_RemoteID);
             this.groupBox_keyData.Controls.Add(this.label_RSK_Hi);
             this.groupBox_keyData.Controls.Add(this.ReadRemote_Button);
             this.groupBox_keyData.Controls.Add(this.button_WriteRemote);
@@ -245,13 +247,24 @@ namespace Hitager
             this.groupBox_keyData.Controls.Add(this.maskedTextBox_RSK_LO);
             this.groupBox_keyData.Controls.Add(this.label_Conf);
             this.groupBox_keyData.Controls.Add(this.maskedTextBox_RSK_HI);
-            this.groupBox_keyData.Controls.Add(this.maskedTextBox_KeyNumber);
+            this.groupBox_keyData.Controls.Add(this.maskedTextBox_RemoteID);
             this.groupBox_keyData.Location = new System.Drawing.Point(12, 2);
             this.groupBox_keyData.Name = "groupBox_keyData";
             this.groupBox_keyData.Size = new System.Drawing.Size(225, 204);
             this.groupBox_keyData.TabIndex = 40;
             this.groupBox_keyData.TabStop = false;
             this.groupBox_keyData.Text = "Key Data";
+            // 
+            // label_CasDumpStatus
+            // 
+            this.label_CasDumpStatus.AutoSize = true;
+            this.label_CasDumpStatus.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_CasDumpStatus.Location = new System.Drawing.Point(110, 43);
+            this.label_CasDumpStatus.Name = "label_CasDumpStatus";
+            this.label_CasDumpStatus.Size = new System.Drawing.Size(112, 17);
+            this.label_CasDumpStatus.TabIndex = 40;
+            this.label_CasDumpStatus.Text = "No dump loaded";
+            this.label_CasDumpStatus.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // BMW_Remote
             // 
@@ -274,11 +287,11 @@ namespace Hitager
         private System.Windows.Forms.Label label_RSK_Hi;
         private System.Windows.Forms.Label label_RSK_lo;
         private System.Windows.Forms.Button ReadRemote_Button;
-        private System.Windows.Forms.Label label_KeyNumber;
+        private System.Windows.Forms.Label label_RemoteID;
         private System.Windows.Forms.Label label_Sync;
         private System.Windows.Forms.Label label_Conf;
         private System.Windows.Forms.Button button_WriteRemote;
-        private System.Windows.Forms.MaskedTextBox maskedTextBox_KeyNumber;
+        private System.Windows.Forms.MaskedTextBox maskedTextBox_RemoteID;
         private System.Windows.Forms.MaskedTextBox maskedTextBox_RSK_HI;
         private System.Windows.Forms.MaskedTextBox maskedTextBox_RSK_LO;
         private System.Windows.Forms.MaskedTextBox maskedTextBox_Sync;
@@ -287,7 +300,8 @@ namespace Hitager
         private System.Windows.Forms.ComboBox comboBox_bankSelect;
         private System.Windows.Forms.Button button_FetchRemoteData;
         private System.Windows.Forms.GroupBox groupBox_CasData;
-        private System.Windows.Forms.Label label_CasDumpStatus;
+        private System.Windows.Forms.Label label_CasDumpStatusLabel;
         private System.Windows.Forms.GroupBox groupBox_keyData;
+        private System.Windows.Forms.Label label_CasDumpStatus;
     }
 }

--- a/sources/Hitager/BMW_Remote.cs
+++ b/sources/Hitager/BMW_Remote.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Threading;
+using System.IO;
 
 namespace Hitager
 {
@@ -15,10 +16,15 @@ namespace Hitager
     {
         private BmwHt2 bmwHt2;
 
+        private String[] bankID = { "0: N/A", "1: N/A", "2: N/A", "3: N/A", "4: N/A", "5: N/A", "6: N/A", "7: N/A", "8: N/A", "9: N/A" };
+
+        private byte[] casDump = new byte[4096];
+
         public BMW_Remote(BmwHt2 bmwHt2)
         {
             this.bmwHt2 = bmwHt2;
             InitializeComponent();
+            comboBox_bankSelect.DataSource = bankID;
         }
 
         private void Read_Remote_Click(object sender, EventArgs e)
@@ -149,6 +155,87 @@ namespace Hitager
             }
 
             bmwHt2.portHandler.portWR("f");
+        }
+
+        private void button_OpenCasDump_Click(object sender, EventArgs e)
+        {
+            String fileContent = string.Empty;
+            String filePath = string.Empty;
+
+
+            using (OpenFileDialog openFileDialog = new OpenFileDialog())
+            {
+                openFileDialog.InitialDirectory = "c:\\";
+                openFileDialog.Filter = "Binary files (*.bin)|*.bin|All files (*.*)|*.*";
+                openFileDialog.FilterIndex = 2;
+                openFileDialog.RestoreDirectory = true;
+
+                if (openFileDialog.ShowDialog() == DialogResult.OK)
+                {
+                    if(new FileInfo(openFileDialog.FileName).Length == 4096)
+                    {
+                        //Get the path of specified file
+                        filePath = openFileDialog.FileName;
+
+                        //Read the contents of the file into a stream
+                        var fileStream = openFileDialog.OpenFile();
+
+                        using (BinaryReader br = new BinaryReader(File.OpenRead(openFileDialog.FileName))) //Sets a new integer to the BinaryReader
+                        {
+                            //casDump = Encoding.UTF8.GetString(br.ReadBytes(4096)); //Reads as many bytes as it can
+                            casDump = br.ReadBytes(4096); //Reads as many bytes as it can
+                            br.Close();
+                        }
+
+                        /* Check the dump */
+
+
+                        for (int i=0; i < 10; i++)
+                        {
+                            byte[] ID_bytearray = new byte[4];
+                            Array.Copy(casDump, (0xA8C + i*4), ID_bytearray, 0, 4);
+                            if (ID_bytearray.SequenceEqual(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }))
+                            {
+                                bankID[i] = i.ToString() + ": Empty";
+                            }
+                            else
+                            {
+                                bankID[i] = i.ToString() + ": " + BitConverter.ToString(ID_bytearray).Replace("-", "");
+                            }
+                                                        
+                        }
+
+                        comboBox_bankSelect.DataSource = null;
+                        comboBox_bankSelect.DataSource = bankID;
+
+
+
+                    }
+                    else
+                    {
+                        String message = "No valid CAS3 dump. Filesize must be 4096 byte!";
+                        String caption = "Warning";
+                        MessageBoxButtons buttons = MessageBoxButtons.OK;
+
+                        DialogResult result = MessageBox.Show(message, caption, buttons);
+                    }
+
+                }
+            }
+        }
+
+        private void button_FetchRemoteData_Click(object sender, EventArgs e)
+        {
+            int BankNr = comboBox_bankSelect.SelectedIndex;
+            byte[] temp = new byte[4];
+
+            /* Remote secret key High */
+            Array.Copy(casDump, (0x848 + BankNr * 2), temp, 0, 2);
+            maskedTextBox_RSK_HI.Text = BitConverter.ToString(temp).Replace("-", "");
+            
+            /* Remote secret key Low */
+            Array.Copy(casDump, (0x860 + BankNr * 4), temp, 0, 4);
+            maskedTextBox_RSK_LO.Text = BitConverter.ToString(temp).Replace("-", "");
         }
     }
 }

--- a/sources/Hitager/BMW_Remote.cs
+++ b/sources/Hitager/BMW_Remote.cs
@@ -80,6 +80,17 @@ namespace Hitager
             {
                 this.maskedTextBox_RSK_HI.Text = remoteDataBlock.Substring((5 * 8) + 4, 4);
                 this.maskedTextBox_RSK_LO.Text = remoteDataBlock.Substring(4 * 8, 8);
+                this.maskedTextBox_KeyNumber.Text = remoteDataBlock.Substring((7 * 8), 4);
+
+                /* Address seems different between PCF7944 and China Key -> Select plausible value */
+                if (remoteDataBlock.Substring(0, 8) == "FFFFFFFF" || remoteDataBlock.Substring(0, 8) == "b1b1b1b1")
+                {
+                    this.maskedTextBox_Sync.Text = remoteDataBlock.Substring((6 * 8), 8);
+                }
+                else
+                {
+                    this.maskedTextBox_Sync.Text = remoteDataBlock.Substring(0, 8);
+                }
             }
             else
             {

--- a/sources/Hitager/Properties/AssemblyInfo.cs
+++ b/sources/Hitager/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Resources;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]		
 
-[assembly: AssemblyVersion("1.1.0.*")]
+[assembly: AssemblyVersion("1.2.0.*")]
 
 [assembly: ComVisible(false)]
 [assembly: NeutralResourcesLanguage("en-US")]


### PR DESCRIPTION
**Key feature:**
Support extracting remote data (RSK_Hi,  RSK_Lo, etc.) from a CAS3 EEPROM dump file. File can be loaded and the data of a selectable key bank (0...9) can be extracted to data fields.
![image](https://user-images.githubusercontent.com/82545992/166112786-4589cc9d-8b95-4a68-9359-7accfd3c43fe.png)



**Improvements:**
- Improve design of "BMW Remote" window

**Bugfix:**
- BMW Remote programming routine: Fix misalignment of "Remote ID" data. The two payload bytes have to be sent first, padded with two zero bytes (before, it was the other way round)