### PR TITLE
Improve compatibility of BMW remote page reading

### DIFF
--- a/Arduino/hitaguino/hitaguino.ino
+++ b/Arduino/hitaguino/hitaguino.ino
@@ -12,15 +12,13 @@
 /* 4MHz clock output for PCF7991 ABIC */
 #if defined(__AVR_ATmega328P__)   // Setting for Arduino Nano and Pro Mini
 const int CLKOUT = 3;
-#elif(__AVR_ATmega2560__)   // Setting for Arduino Nano and Pro Mini
+#elif(__AVR_ATmega2560__)   // Setting for Arduino Mega 2560
 const int CLKOUT = 9;
 #endif
 
 const int SCK_pin = 6;
 const int dout_pin = 7;
-//const int din_pin = 21; // Arduino Mega2560 original value 21 Mega2560 can also use 2 
-const int din_pin = 2; //Use with Arduino Nano
-//Note: din_pin must have external interrupt feature!
+const int din_pin = 2;   //Note: din_pin must have external interrupt feature!
 const int test_pin = 4;
 
 const char hitagerVersion[] = {"211"};  // Major Version, Minor Version, Fix

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Additional infos can be found at the homepage of the project initiator's [websit
 
 ## Main Features:
 - Supported Protocols:
-  - Hitag2, Hitag2+EE, Hitag2 Extended, Hitag2 BMW Extention
+  - Hitag2, Hitag2+EE, Hitag2 Extended, Hitag2 BMW EE Extention
   - Hitag3
   - Hitag AES
   - Hitag Pro
@@ -24,10 +24,10 @@ AESHitager PC <-------> Arduino <-------> PCF7991 IC <- - - - -> Key Transponder
 
 1. **Arduino**  
   - Download the latest Hitaguino release from the Github page
-  - **Option 1:**   
+  - **Flash Arduino (Option 1):**   
     Use Avrdudess (https://github.com/ZakKemble/AVRDUDESS, ~2MB) for uploading the .hex file only (Select "Arduino" as Programmer, Select proper COM Port, Baud Rate "115200", select .hex file in "Flash" section, click Go, wait until programming finished)
  
-   - **Option 2:**   
+   - **Flash Arduino (Option 2):**   
    Open the .ino file in your arduino IDE, compile & upload it to the board  
      
       **Hint:** It might be necessary to press and release the reset button on the araduino board shortly before upload process starts.
@@ -51,7 +51,7 @@ AESHitager PC <-------> Arduino <-------> PCF7991 IC <- - - - -> Key Transponder
    **Hint 2:**  
    Connecting GND is only required if not connected via USB. In this case connect Arduino GND to PCB GND (not directly at ABIC GND pin)
    
-   **Variants:**
+   **Hardware Variants:**
     - **Hitag2 v3.1, ZedBull Mini** (and others boards with on-board crystal oscillator and µC):  
       - Connect Arduino according to table
       - Do not connect D3, as clock source is already present at the PCB
@@ -60,5 +60,6 @@ AESHitager PC <-------> Arduino <-------> PCF7991 IC <- - - - -> Key Transponder
     - **IPROG RFID Adapter**
       - The adapter can be used without any modification on the PCB
       - Connect with arduino according to table column "IPROG  D-Sub Pin"   <br>
-      <br>      
-      <img src="/documentation/D_SUB_44_IPROG_Connector.jpg" width=50% height=50%>
+      - Below the schematic of the Iprog PCB:
+      <img src="https://user-images.githubusercontent.com/82545992/183724661-752b45e0-bc28-4f21-9efb-90c9170f3230.png" width=30% height=30%>
+

--- a/README.md
+++ b/README.md
@@ -35,14 +35,16 @@ AESHitager PC <-------> Arduino <-------> PCF7991 IC <- - - - -> Key Transponder
 2. **RFID Reader**  
    It is possible to use any available PCB containing a PCF7991 base station IC (ABIC). The cheapest solution seems to be IPROG RFID Adapter (available for ~ 15$)
    
-   | Arduino Pin  | PCF7991 Pin Nr. | ABIC Pin Name | IPROG D-SUB PIN |
+   | Arduino Nano Pin  | PCF7991 Pin Nr. | PCF7991 Pin Name | IPROG D-SUB PIN |
    | :------------: | :----------: | :-----------: | :-------------: |
    |        D2      |      10      |       DOUT    |         5       |
    |        D7      |       9      |       DIN     |         3       |
    |        D6      |       8      |       CLK     |         4       |
-   |  D3 (optional) |       6      |      XTAL1    |        20       |
+   |  D3 / D9* (optional) |       6      |      XTAL1    |        20       |
    | GND (optional) |  (see Hint)  |   (see Hint)  |        36       |
    |   VCC / +5V    |      -       |        -      |        32       |
+   
+   \* : For Arduino Mega 2560
    
    <img src="/documentation/PCF7991_Footprint.JPG" width=30% height=30%>
    

--- a/sources/Hitager/BmwHt2.cs
+++ b/sources/Hitager/BmwHt2.cs
@@ -155,6 +155,7 @@ namespace Hitager
 
             for (int j = blockAddressStart; j <= blockAddressEnd; j++)
             {
+                bool LvSpclPrcdRead = false;    // "Special procedure required"indicator
                 /* Select the block */
                 if (!(j == 0 || j == 31))
                 {
@@ -178,6 +179,7 @@ namespace Hitager
                 {
                     String received = "00000000";
                     
+
                     if (((j == 14 && i == 7) || j == 31))
                     {
                         /* Not readable pages */
@@ -185,11 +187,24 @@ namespace Hitager
                     }
                     else if (j == 15 || j==0)
                     {
-                        /* Special procedure for reading protected block PCF7944 5WK49121 */
-                        Thread.Sleep(10);
-                        sendCmdUntilResponse("i0540", "FFFFFFE8", 5);
-                        Thread.Sleep(10);
-                        received = ReadPage(i);
+                        if(LvSpclPrcdRead == false)
+                        {
+                            received = ReadPage(i);
+                        }
+                        
+                        if (received.Equals("B1B1B1B1") || LvSpclPrcdRead==true)
+                        {
+                            /* Try Special procedure for reading protected block PCF7944 5WK49121 */
+                            Thread.Sleep(10);
+                            sendCmdUntilResponse("i0540", "FFFFFFE8", 5);
+                            Thread.Sleep(10);
+                            received = ReadPage(i);
+                            if (!received.Equals("B1B1B1B1"))
+                            {
+                                /* If special reading procedure was successful, remember this for next block */
+                                LvSpclPrcdRead = true;
+                            }
+                        }
                     }
                     else
                     {

--- a/sources/Hitager/Properties/AssemblyInfo.cs
+++ b/sources/Hitager/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Resources;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]		
 
-[assembly: AssemblyVersion("1.3.1.*")]
+[assembly: AssemblyVersion("1.3.2.*")]
 
 [assembly: ComVisible(false)]
 [assembly: NeutralResourcesLanguage("en-US")]


### PR DESCRIPTION
This commit makes BMW remote page (Pg15) working for all known key types:
- PCF7945 5WK49125 with Pg15 not locked
- PCF7944 (old CAS key) with Pg15 locked
- 26A0700 (china key) with Pg15 locked